### PR TITLE
[36기 김진혁] HostPage SignUp 구현

### DIFF
--- a/src/pages/Host/Host.js
+++ b/src/pages/Host/Host.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import HostSignUp from './HostSignUp/HostSignUp';
 
 const Host = () => {
-  return <div>Host</div>;
+  return <HostSignUp />;
 };
 
 export default Host;

--- a/src/pages/Host/HostSignUp/HostSignUp.js
+++ b/src/pages/Host/HostSignUp/HostSignUp.js
@@ -1,0 +1,216 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import variables from '../../../styles/variables';
+
+function HostSignUp() {
+  const [hostInfo, setHostInfo] = useState({
+    name: '',
+    nick: '',
+    email: '',
+    phone: '',
+  });
+
+  const hostInfoHandle = ({ target }) => {
+    setHostInfo({ ...hostInfo, [target.name]: target.value });
+  };
+
+  const navigate = useNavigate();
+
+  const hostInfoPost = () => {
+    fetch(`http://10.58.4.165:3000/host/register`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: 3,
+        email: hostInfo.email,
+        phone: hostInfo.phone,
+      }),
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.message === 'HOST_REGISTRATION_COMPLETE') {
+          navigate('/HostPostInfo');
+        } else {
+          alert('가입 양식을 올바르게 작성해주세요.');
+        }
+      });
+  };
+
+  return (
+    <HostStyleContainer>
+      <HostStyleImage>
+        <HostStyleImageTitle>호스팅을 시작해보세요.</HostStyleImageTitle>
+      </HostStyleImage>
+      <HostStyleSectionContainer>
+        <HostStyleSectionIntro>
+          <HostStyleSectionIntroLink to="/">⇱ 나가기</HostStyleSectionIntroLink>
+          <HostStyleSectionIntroTitle>
+            호스트님 안녕하세요.
+          </HostStyleSectionIntroTitle>
+        </HostStyleSectionIntro>
+        <HostStyleSectionInputWrap onChange={hostInfoHandle}>
+          <HostStyleSectionLabel>
+            Name
+            <HostStyleSectionInput
+              type="text"
+              name="name"
+              defaultValue={hostInfo.name}
+            />
+          </HostStyleSectionLabel>
+          <HostStyleSectionLabel>
+            Nick name
+            <HostStyleSectionInput
+              type="text"
+              name="nick"
+              defaultValue={hostInfo.nick}
+            />
+          </HostStyleSectionLabel>
+          <HostStyleSectionLabel>
+            E-mail
+            <HostStyleSectionInput
+              type="email"
+              name="email"
+              defaultValue={hostInfo.email}
+            />
+          </HostStyleSectionLabel>
+          <HostStyleSectionLabel>
+            Phone
+            <HostStyleSectionInput
+              type="tel"
+              name="phone"
+              defaultValue={hostInfo.phone}
+              placeholder=" - 기호를 빼고 입력해주세요."
+            />
+          </HostStyleSectionLabel>
+        </HostStyleSectionInputWrap>
+        <HostStyleSectionRegistration>
+          <HostStyleSectionRegistrationButton onClick={hostInfoPost}>
+            등록
+          </HostStyleSectionRegistrationButton>
+        </HostStyleSectionRegistration>
+      </HostStyleSectionContainer>
+    </HostStyleContainer>
+  );
+}
+
+export default HostSignUp;
+
+const HostStyleContainer = styled.div`
+  ${variables.flex('row', 'space-between', 'center')};
+  width: 100%;
+  height: 100vh;
+  background-color: #fff0f0;
+  box-shadow: 0px 0px 20px 5px ${({ theme }) => theme.GrayHavy};
+`;
+
+const HostStyleImage = styled.div`
+  ${variables.flex('column')};
+  width: 50%;
+  height: 100%;
+  text-align: center;
+  font-size: 48px;
+  font-weight: 800;
+  color: ${({ theme }) => theme.White};
+  background: linear-gradient(180deg, purple, hotpink, #58c, hotpink);
+`;
+
+const HostStyleImageTitle = styled.h1`
+  line-height: 100%;
+`;
+
+const HostStyleSectionContainer = styled.section`
+  ${variables.flex('column')};
+  width: 50%;
+  height: 100%;
+  transition: 0.1s;
+
+  &:hover {
+    border-top-right-radius: 15px;
+    border-bottom-right-radius: 15px;
+    background-color: ${({ theme }) => theme.White};
+  }
+`;
+
+const HostStyleSectionInputWrap = styled.form`
+  ${variables.flex('column', '', 'flex-start')};
+  margin-bottom: 60px;
+  font-size: 20px;
+  font-weight: 500;
+  color: #e53170;
+`;
+const HostStyleSectionLabel = styled.label` {
+    ${variables.flex('column', '', 'flex-start')};
+    margin-top: 30px;
+`;
+const HostStyleSectionInput = styled.input`
+   {
+    width: 335px;
+    height: 25px;
+    margin-top: 10px;
+    padding: 30px 20px;
+    border: 1px solid #d6d6d6;
+    border-radius: 11px;
+    font-size: 20px;
+
+    &:hover {
+      box-shadow: 0px 0px 5px 1px #c0c0c0;
+    }
+  }
+`;
+
+const HostStyleSectionIntro = styled.div`
+  ${variables.flex('row-reverse', 'space-around')}
+  position: relative;
+  width: 100%;
+  height: 100vh;
+`;
+const HostStyleSectionIntroLink = styled(Link)`
+  position: absolute;
+  margin: 30px 30px 0px 0px;
+  top: 0;
+  right: 0;
+  text-decoration: none;
+  font-size: 25px;
+  color: black;
+  background-color: rgba(0, 0, 0, 0.01);
+  border: none;
+  cursor: pointer;
+`;
+
+const HostStyleSectionIntroTitle = styled.h1`
+  position: absolute;
+  top: 50%;
+  left: 10%;
+  font-size: 30px;
+  font-weight: 900;
+  white-space: pre-wrap;
+`;
+
+const HostStyleSectionRegistration = styled.div`
+  ${variables.flex('', 'flex-end')}
+  width: 100%;
+  height: 50vh;
+  border-bottom-right-radius: 15px;
+  background-color: #fff0f0;
+  box-shadow: 0px -5px 10px 0px #c0c0c0;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.White};
+  }
+`;
+
+const HostStyleSectionRegistrationButton = styled.button`
+  width: 100px;
+  height: 40px;
+  margin-right: 30px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  background-color: #e53170;
+  cursor: pointer;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Host 가입
호스트 등록을 하지 않은 유저는 "호스트 모드로 전환" 버튼을 클릭시 호스트 sign up 페이지로 이동합니다.
- Host 정보를 입력하고 등록을 누르면 숙소 등록 페이지로 이동합니다.
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 기존 애어비앤비 페이지 컨셉(디자인)과 유사한 UI 구현
- Styled Components를 이용해 Host SignUp 페이지를 애어비엔비 컨셉을 유지하여 구현했습니다.
- 애어비앤비
![에어비앤비 등록페이지](https://user-images.githubusercontent.com/85611408/188775584-91c85605-6d67-476d-86f5-81e784ae90ea.JPG)
- 위앤비
![호스트 등록 페이지](https://user-images.githubusercontent.com/85611408/188775625-616f78af-beaa-498a-985f-de40969d112f.JPG)

2. input 값 state에 저장
- 계산된 속성명을 활용하여 하나의 state로 각각의 input값을 핸들링해주었습니다.


## :: 리뷰 반영 사항
1. styled component 개별 선언 방식으로 수정 (객체로 구분 X)
2. input 태그 label 태그로 감싸주어 불 필요한 속성 제거
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 기존 애어비앤비 host 숙소 등록 페이지는 현재 수준에서 구현하기 어려운 부분이 있어서, 기존에 없는 새로운 페이지 UI를 구상해야되는 상황이었습니다. user와 페이지에서 이뤄지는 상호작용을 어떻게 하면 자연스럽고 부드럽게 구현할지 고민 해볼 수 있던 경험이 되었습니다.

<br />

## :: 기타 질문 및 특이 사항-
- styled components 여러가지 사용 예시 중 객체 형식으로 사용한 예시를 사용해보았습니다. 단순히 이 방식이 편해보여서 사용했지만 상황별로 어떻게 사용하는게 적합한 것인지 궁금합니다.

